### PR TITLE
[Aula 8] Adiciona instalação do `punkt` e `requirements.txt`

### DIFF
--- a/aula-08/modelo-linguagem.ipynb
+++ b/aula-08/modelo-linguagem.ipynb
@@ -2,12 +2,33 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 1,
    "id": "60d71a4c-1089-4418-98f3-66a017370a0f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[nltk_data] Downloading package punkt to /home/adame/nltk_data...\n",
+      "[nltk_data]   Unzipping tokenizers/punkt.zip.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "import nltk"
+    "import nltk\n",
+    "# Se necessário\n",
+    "nltk.download('punkt')"
    ]
   },
   {
@@ -22,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "id": "4e2989d2-5cb2-4013-bcc3-8c71e3826c55",
    "metadata": {},
    "outputs": [],
@@ -38,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "id": "b6a33d35-a9eb-4dfd-87b2-df18bb14ecf4",
    "metadata": {},
    "outputs": [
@@ -51,7 +72,7 @@
        " ['no', 'meio', 'do', 'caminho', 'tinha', 'uma', 'pedra', '.']]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -65,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 4,
    "id": "c8763946-38e6-4727-8616-4ae49826f1bf",
    "metadata": {},
    "outputs": [
@@ -78,7 +99,7 @@
        " ['no', 'meio', 'do', 'caminho', 'tinha', 'uma', 'pedra', '.']]"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -104,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "id": "48bd0746-cfb9-45be-a13e-50592420e60e",
    "metadata": {},
    "outputs": [
@@ -117,7 +138,7 @@
        " ['<s>', 'no', 'meio', 'do', 'caminho', 'tinha', 'uma', 'pedra', '.', '</s>']]"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -132,13 +153,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "id": "0a454f4e-55a9-41d7-b831-08afc70e77a6",
    "metadata": {
-    "collapsed": true,
-    "jupyter": {
-     "outputs_hidden": true
-    },
     "tags": []
    },
    "outputs": [
@@ -209,7 +226,7 @@
        "  ('</s>',)]]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -224,13 +241,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 7,
    "id": "526052c5-989c-4a27-a419-bccaf87a0960",
    "metadata": {
-    "collapsed": true,
-    "jupyter": {
-     "outputs_hidden": true
-    },
     "tags": []
    },
    "outputs": [
@@ -272,7 +285,7 @@
        " '</s>']"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -287,13 +300,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 8,
    "id": "d7360358-e59e-4b41-bd36-8c0eca344924",
    "metadata": {
-    "collapsed": true,
-    "jupyter": {
-     "outputs_hidden": true
-    },
     "tags": []
    },
    "outputs": [
@@ -313,7 +322,7 @@
        " '<UNK>']"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -328,7 +337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 9,
    "id": "1375e5c6-ebc7-4de1-87aa-8ac790a3a92c",
    "metadata": {},
    "outputs": [],
@@ -349,17 +358,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 10,
    "id": "ddfb9ea3-49e5-4969-8760-30d0e0ca0ea2",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['meio', 'do', 'caminho', 'tinha', 'uma']"
+       "['meio', 'do', 'caminho', '</s>', '<s>']"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -370,7 +379,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 11,
    "id": "7b9eb3c0-394d-419f-801f-5897a7a997aa",
    "metadata": {},
    "outputs": [
@@ -380,7 +389,7 @@
        "(0.09090909090909091, -3.4594316186372978)"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -391,7 +400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 12,
    "id": "699d1272-2ead-4c8d-ad1e-44ef80e24b1a",
    "metadata": {},
    "outputs": [
@@ -401,7 +410,7 @@
        "(0.6666666666666666, -0.5849625007211563)"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -427,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 13,
    "id": "64bb7377-e6d1-48fa-a33f-dd6c0e5c8f8d",
    "metadata": {},
    "outputs": [
@@ -476,7 +485,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 14,
    "id": "555d157d-7cbb-4885-a99c-b3cff883c77e",
    "metadata": {},
    "outputs": [
@@ -486,7 +495,7 @@
        "0.21428571428571427"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -503,7 +512,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 15,
    "id": "1332e9bb-f014-4d68-a725-09e2598fcb7a",
    "metadata": {},
    "outputs": [
@@ -513,7 +522,7 @@
        "0.5121951219512195"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/aula-08/requirements.txt
+++ b/aula-08/requirements.txt
@@ -1,0 +1,2 @@
+jupyterlab==3.4.5
+nltk==3.7


### PR DESCRIPTION
Basicamente adicionei o comando para instalação do `punkt` na primeira célula e adicionei um simples `requirements.txt` (que não contêm as dependências dos dois pacotes) para a instalação facilitada através de:
```bash
pip install -r requirements.txt
```